### PR TITLE
Fix Package.swift configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ import PackageDescription
 
 let package = Package(
     name: "soto-s3-file-transfer",
+    platforms: [.iOS(.v12), .tvOS(.v12), .watchOS(.v5)],
     products: [
         .library(name: "SotoS3FileTransfer", targets: ["SotoS3FileTransfer"]),
     ],


### PR DESCRIPTION
This is required to work in newer SPM tooling

If you don't specify platform explicit it will assume older versions and you'll have a mismatch between this and Soto main package file preventing compilation