### PR TITLE
Update S3FileTransferManager.swift

### DIFF
--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -494,7 +494,7 @@ extension S3FileTransferManager {
             let files: [S3FileDescriptor] = response.contents?.compactMap {
                 guard let key = $0.key,
                       let lastModified = $0.lastModified,
-                      let fileSize = $0.size else { return nil }
+                      let fileSize = $0.size == 0 ? nil : $0.size else { return nil }
                 return S3FileDescriptor(
                     file: S3File(bucket: folder.bucket, key: key),
                     modificationDate: lastModified,


### PR DESCRIPTION
This listFiles function was returning an erroneous extra file name in the format bucket/key/ and it caused the sync function to say that the file did not exist when trying to copy it into my local directory. 