### PR TITLE
Validate S3 file list can be downloaded to file system

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.build
+.git

--- a/Sources/SotoS3FileTransfer/S3FileTransferManager+options.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager+options.swift
@@ -120,7 +120,10 @@ extension S3FileTransferManager {
         /// VersionId used to reference a specific version of the object.
         public let versionId: String?
 
-        public init(expectedBucketOwner: String? = nil, ifMatch: String? = nil, ifModifiedSince: Date? = nil, ifNoneMatch: String? = nil, ifUnmodifiedSince: Date? = nil, requestPayer: S3.RequestPayer? = nil, sSECustomerAlgorithm: String? = nil, sSECustomerKey: String? = nil, sSECustomerKeyMD5: String? = nil, versionId: String? = nil) {
+        /// Ignore file folder clashes when downloading folders. When set to true the file is not downloaded
+        public let ignoreFileFolderClashes: Bool
+
+        public init(expectedBucketOwner: String? = nil, ifMatch: String? = nil, ifModifiedSince: Date? = nil, ifNoneMatch: String? = nil, ifUnmodifiedSince: Date? = nil, requestPayer: S3.RequestPayer? = nil, sSECustomerAlgorithm: String? = nil, sSECustomerKey: String? = nil, sSECustomerKeyMD5: String? = nil, versionId: String? = nil, ignoreFileFolderClashes: Bool = false) {
             self.expectedBucketOwner = expectedBucketOwner
             self.ifMatch = ifMatch
             self.ifModifiedSince = ifModifiedSince
@@ -131,6 +134,8 @@ extension S3FileTransferManager {
             self.sSECustomerKey = sSECustomerKey
             self.sSECustomerKeyMD5 = sSECustomerKeyMD5
             self.versionId = versionId
+
+            self.ignoreFileFolderClashes = ignoreFileFolderClashes
         }
     }
 

--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -50,6 +50,7 @@ public struct S3FileTransferManager {
         case fileDoesNotExist(String)
         case failedToCreateFolder(String)
         case failedToEnumerateFolder(String)
+        case fileFolderClash(String, String)
     }
 
     /// S3 service object
@@ -290,6 +291,7 @@ public struct S3FileTransferManager {
     ) -> EventLoopFuture<Void> {
         let eventLoop = self.s3.eventLoopGroup.next()
         return listFiles(in: s3Folder)
+            .flatMapThrowing { try self.validateFileList($0) }
             .flatMap { files in
                 let taskQueue = TaskQueue<Void>(maxConcurrentTasks: configuration.maxConcurrentTasks, on: eventLoop)
                 let transfers = Self.targetFiles(files: files, from: s3Folder, to: folder)
@@ -398,7 +400,7 @@ public struct S3FileTransferManager {
     ) -> EventLoopFuture<Void> {
         let eventLoop = self.s3.eventLoopGroup.next()
 
-        return listFiles(in: folder).and(listFiles(in: s3Folder))
+        return listFiles(in: folder).and(listFiles(in: s3Folder).flatMapThrowing { try self.validateFileList($0) })
             .flatMap { files, s3Files in
                 let taskQueue = TaskQueue<Void>(maxConcurrentTasks: configuration.maxConcurrentTasks, on: eventLoop)
                 let targetFiles = Self.targetFiles(files: s3Files, from: s3Folder, to: folder)
@@ -564,6 +566,25 @@ extension S3FileTransferManager {
                 )
             } ?? []
             return eventLoop.makeSucceededFuture((true, accumulator + files))
+        }
+    }
+
+    /// Validate we can save file list from S3 to file system
+    ///
+    /// Look for files that are the same name as directory names in other files
+    func validateFileList(_ list: [S3FileDescriptor]) throws -> [S3FileDescriptor] {
+        let list = list.sorted { $0.file.key < $1.file.key }
+        return try list.filter { file -> Bool in
+            let filename = file.file.key
+            for file2 in list {
+                let filename2 = file2.file.key
+                if filename2.hasPrefix(filename),
+                   (filename.last == "/" || filename2.dropFirst(filename.count).first == "/") {
+                    throw Error.fileFolderClash(filename2, filename)
+                    //return false
+                }
+            }
+            return true
         }
     }
 


### PR DESCRIPTION
S3 does not have a proper file system. It just has key -> object map. It pretends it has a fake filesystem by using the "/" to split keys into folders. This creates a problem though. In S3 you can have a key representing an object while still being a folder name for another key. This cannot be represented in a file system.

This PR throws an error when it finds a file folder clash like this, or with an `ignoreFileFolderClashes` flag will ignore the key associated with the folder.