### PR TITLE
Fix: Use unique key for S3Files for folder copy progress

### DIFF
--- a/Sources/SotoS3FileTransfer/FolderUploadProgress.swift
+++ b/Sources/SotoS3FileTransfer/FolderUploadProgress.swift
@@ -26,7 +26,7 @@ extension S3FileTransferManager {
 
         init(_ s3Files: [S3FileDescriptor], progress: @escaping (Double) throws -> Void = { _ in }) {
             self.lock = Lock()
-            self.sizes = .init(s3Files.map { (key: $0.file.name, value: UInt64($0.size)) }) { first, _ in first }
+            self.sizes = .init(s3Files.map { (key: $0.file.key, value: UInt64($0.size)) }) { first, _ in first }
             self.totalSize = self.sizes.values.reduce(UInt64(0), +)
             self.uploadedSize = 0
             self.currentUploadingSizes = [:]

--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -303,9 +303,9 @@ public struct S3FileTransferManager {
                 transfers.forEach { transfer in
                     taskQueue.submitTask {
                         self.copy(from: transfer.from.file, to: transfer.to, options: options) {
-                            try folderProgress.updateProgress(transfer.from.file.name, progress: $0)
+                            try folderProgress.updateProgress(transfer.from.file.key, progress: $0)
                         }.map { _ in
-                            folderProgress.setFileUploaded(transfer.from.file.name)
+                            folderProgress.setFileUploaded(transfer.from.file.key)
                         }
                     }
                 }
@@ -421,9 +421,9 @@ public struct S3FileTransferManager {
                 transfers.forEach { transfer in
                     taskQueue.submitTask {
                         self.copy(from: transfer.from.file, to: transfer.to, options: options) {
-                            try folderProgress.updateProgress(transfer.from.file.name, progress: $0)
+                            try folderProgress.updateProgress(transfer.from.file.key, progress: $0)
                         }.map { _ in
-                            folderProgress.setFileUploaded(transfer.from.file.name)
+                            folderProgress.setFileUploaded(transfer.from.file.key)
                         }
                     }
                 }


### PR DESCRIPTION
When copying a folder from S3 to local, in `copy(from s3Folder: S3Folder, to folder: String...)` FolderUploadProgress's init was using S3File.name to calculate total size of all the files.  S3File.name will not be unique if there are two or more files with the same filename in different subfolders. For example if you tried to download this folder from S3 it would assert `assert(folderProgress.finished == true)`:

```
file.txt
subfolder/file.txt
```