### PR TITLE
Speed up transfer/deletion list creation when syncing

### DIFF
--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -394,7 +394,6 @@ public class S3FileTransferManager {
                 let folderResolved = URL(fileURLWithPath: folder).standardizedFileURL.resolvingSymlinksInPath()
                 let targetFiles = Self.targetFiles(files: files, from: folderResolved.path, to: s3Folder)
                 let s3KeyMap = Dictionary(uniqueKeysWithValues: s3Files.map { ($0.file.key, $0) })
-                let targetKeyMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to.key, $0) })
                 let transfers = targetFiles.compactMap { transfer -> (from: FileDescriptor, to: S3File)? in
                     // does file exist on S3
                     guard let s3File = s3KeyMap[transfer.to.key] else { return transfer }
@@ -414,6 +413,7 @@ public class S3FileTransferManager {
                 }
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
+                    let targetKeyMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to.key, $0) })
                     let deletions = s3Files.compactMap { s3File -> S3File? in
                         if targetKeyMap[s3File.file.key] == nil {
                             return s3File.file
@@ -454,7 +454,6 @@ public class S3FileTransferManager {
                 let taskQueue = TaskQueue<Void>(maxConcurrentTasks: self.configuration.maxConcurrentTasks, on: eventLoop)
                 let targetFiles = Self.targetFiles(files: s3Files, from: s3Folder, to: folder)
                 let fileNameMap = Dictionary(uniqueKeysWithValues: files.map { ($0.name, $0) })
-                let targetToMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to, $0) })
                 let transfers = targetFiles.compactMap { transfer -> (from: S3FileDescriptor, to: String)? in
                     // does file exist locally
                     guard let file = fileNameMap[transfer.to] else { return transfer }
@@ -464,6 +463,7 @@ public class S3FileTransferManager {
                 }
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
+                    let targetToMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to, $0) })
                     let deletions = files.compactMap { file -> String? in
                         if targetToMap[file.name] == nil {
                             return file.name
@@ -505,7 +505,6 @@ public class S3FileTransferManager {
                 let taskQueue = TaskQueue<Void>(maxConcurrentTasks: self.configuration.maxConcurrentTasks, on: eventLoop)
                 let targetFiles = Self.targetFiles(files: srcFiles, from: srcFolder, to: destFolder)
                 let destKeyMap = Dictionary(uniqueKeysWithValues: destFiles.map { ($0.file.key, $0) })
-                let targetKeyMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to.key, $0) })
                 let transfers = targetFiles.compactMap { transfer -> (from: S3FileDescriptor, to: S3File)? in
                     // does file exist in destination folder
                     guard let file = destKeyMap[transfer.to.key] else { return transfer }
@@ -518,6 +517,7 @@ public class S3FileTransferManager {
                 }
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
+                    let targetKeyMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to.key, $0) })
                     let deletions = destFiles.compactMap { file -> S3File? in
                         if targetKeyMap[file.file.key] == nil {
                             return file.file

--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -413,12 +413,12 @@ public class S3FileTransferManager {
                 }
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
-                    let targetKeyMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to.key, $0) })
+                    let targetKeys = Set(targetFiles.map { $0.to.key })
                     let deletions = s3Files.compactMap { s3File -> S3File? in
-                        if targetKeyMap[s3File.file.key] == nil {
-                            return s3File.file
-                        } else {
+                        if targetKeys.contains(s3File.file.key) {
                             return nil
+                        } else {
+                            return s3File.file
                         }
                     }
                     deletions.forEach { deletion in taskQueue.submitTask { self.delete(deletion) } }
@@ -463,12 +463,12 @@ public class S3FileTransferManager {
                 }
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
-                    let targetToMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to, $0) })
+                    let targetTos = Set(targetFiles.map { $0.to })
                     let deletions = files.compactMap { file -> String? in
-                        if targetToMap[file.name] == nil {
-                            return file.name
-                        } else {
+                        if targetTos.contains(file.name) {
                             return nil
+                        } else {
+                            return file.name
                         }
                     }
                     deletions.forEach { deletion in taskQueue.submitTask { self.delete(deletion) } }
@@ -517,12 +517,12 @@ public class S3FileTransferManager {
                 }
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
-                    let targetKeyMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to.key, $0) })
+                    let targetKeys = Set(targetFiles.map { $0.to.key })
                     let deletions = destFiles.compactMap { file -> S3File? in
-                        if targetKeyMap[file.file.key] == nil {
-                            return file.file
-                        } else {
+                        if targetKeys.contains(file.file.key) {
                             return nil
+                        } else {
+                            return file.file
                         }
                     }
                     deletions.forEach { deletion in taskQueue.submitTask { self.delete(deletion) } }

--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -453,9 +453,11 @@ public class S3FileTransferManager {
             .flatMap { files, s3Files in
                 let taskQueue = TaskQueue<Void>(maxConcurrentTasks: self.configuration.maxConcurrentTasks, on: eventLoop)
                 let targetFiles = Self.targetFiles(files: s3Files, from: s3Folder, to: folder)
+                let fileNameMap = Dictionary(uniqueKeysWithValues: files.map { ($0.name, $0) })
+                let targetToMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to, $0) })
                 let transfers = targetFiles.compactMap { transfer -> (from: S3FileDescriptor, to: String)? in
                     // does file exist locally
-                    guard let file = files.first(where: { $0.name == transfer.to }) else { return transfer }
+                    guard let file = fileNameMap[transfer.to] else { return transfer }
                     // does local file have a later date
                     guard file.modificationDate > transfer.from.modificationDate else { return transfer }
                     return nil
@@ -463,7 +465,7 @@ public class S3FileTransferManager {
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
                     let deletions = files.compactMap { file -> String? in
-                        if targetFiles.first(where: { $0.to == file.name }) == nil {
+                        if targetToMap[file.name] == nil {
                             return file.name
                         } else {
                             return nil
@@ -502,9 +504,11 @@ public class S3FileTransferManager {
             .flatMap { srcFiles, destFiles in
                 let taskQueue = TaskQueue<Void>(maxConcurrentTasks: self.configuration.maxConcurrentTasks, on: eventLoop)
                 let targetFiles = Self.targetFiles(files: srcFiles, from: srcFolder, to: destFolder)
+                let destKeyMap = Dictionary(uniqueKeysWithValues: destFiles.map { ($0.file.key, $0) })
+                let targetKeyMap = Dictionary(uniqueKeysWithValues: targetFiles.map { ($0.to.key, $0) })
                 let transfers = targetFiles.compactMap { transfer -> (from: S3FileDescriptor, to: S3File)? in
                     // does file exist in destination folder
-                    guard let file = destFiles.first(where: { $0.file.key == transfer.to.key }) else { return transfer }
+                    guard let file = destKeyMap[transfer.to.key] else { return transfer }
                     // does local file have a later date
                     guard file.modificationDate > transfer.from.modificationDate else { return transfer }
                     return nil
@@ -515,7 +519,7 @@ public class S3FileTransferManager {
                 // construct list of files to delete, if we are doing deletion
                 if delete == true {
                     let deletions = destFiles.compactMap { file -> S3File? in
-                        if targetFiles.first(where: { $0.to.key == file.file.key }) == nil {
+                        if targetKeyMap[file.file.key] == nil {
                             return file.file
                         } else {
                             return nil


### PR DESCRIPTION
In case of large file sets (70-80k for instance), the compact maps to compute the transfer and deletion lists are very, very slow (many minutes on an M1 Mac) due to the `first` lookups to find key matches.

Using the two maps brings them down to <1s each.

I haven't tried to measure the memory impact but I'm guessing (hoping!) it won't be that much because the elements would be copy-on-write referenced?