### PR TITLE
Expose `S3FileTransferManager.listFiles()` as `public`

### DIFF
--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -561,10 +561,10 @@ extension S3FileTransferManager {
         let size: Int
     }
 
-    struct S3FileDescriptor: Equatable {
-        let file: S3File
-        let modificationDate: Date
-        let size: Int
+    public struct S3FileDescriptor: Equatable {
+        public let file: S3File
+        public let modificationDate: Date
+        public let size: Int
     }
 
     /// List files in local folder
@@ -597,7 +597,7 @@ extension S3FileTransferManager {
     }
 
     /// List files in S3 folder
-    func listFiles(in folder: S3Folder) async throws -> [S3FileDescriptor] {
+    public func listFiles(in folder: S3Folder) async throws -> [S3FileDescriptor] {
         let request = S3.ListObjectsV2Request(bucket: folder.bucket, prefix: folder.key)
         var files: [S3FileDescriptor] = []
         for try await objects in self.s3.listObjectsV2Paginator(request, logger: self.logger) {

--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -561,9 +561,13 @@ extension S3FileTransferManager {
         let size: Int
     }
 
+    /// A descriptor representing a file stored in an S3 bucket.
     public struct S3FileDescriptor: Equatable {
+        /// The S3 file represented by this descriptor.
         public let file: S3File
+        /// The date and time when the file was last modified.
         public let modificationDate: Date
+        /// The size of the file in bytes.
         public let size: Int
     }
 
@@ -596,7 +600,12 @@ extension S3FileTransferManager {
         }
     }
 
-    /// List files in S3 folder
+    /// Lists all files in the specified S3 folder.
+    ///
+    /// - Parameters:
+    ///   - in: Path to remote S3 folder to list files from.
+    /// - Returns: An array of `S3FileDescriptor` objects representing the files in the specified folder. If the directory contains no files, this method returns an empty array.
+    /// - Throws: An error if the folder cannot be accessed or if there is any other issue listing the files.
     public func listFiles(in folder: S3Folder) async throws -> [S3FileDescriptor] {
         let request = S3.ListObjectsV2Request(bucket: folder.bucket, prefix: folder.key)
         var files: [S3FileDescriptor] = []


### PR DESCRIPTION
Change as asked in https://github.com/soto-project/soto-s3-file-transfer/issues/40

Expose `listFiles(in folder: S3Folder)` func and `S3FileDescriptor` struct as public. `S3File` that `S3FileDescriptor` depends on is already public.