### PR TITLE
Truncate file prior writing to it in order to avoid data corruption

### DIFF
--- a/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
+++ b/Sources/SotoS3FileTransfer/S3FileTransferManager.swift
@@ -223,7 +223,9 @@ public final class S3FileTransferManager: Sendable {
             }
             return to
         }
-        try await self.fileIO.withFileHandle(path: filename, mode: .write, flags: .allowFileCreation()) { fileHandle in
+        // if the file exists truncate prior writting to it
+        let fileHandleFlags = NIOFileHandle.Flags.posix(flags: O_CREAT | O_TRUNC, mode: NIOFileHandle.Flags.defaultPermissions)
+        try await self.fileIO.withFileHandle(path: filename, mode: .write, flags: fileHandleFlags) { fileHandle in
             let request = S3.GetObjectRequest(bucket: from.bucket, key: from.key, options: options)
             let response = try await self.s3.getObject(request, logger: self.logger)
             var bytesDownloaded = 0


### PR DESCRIPTION
Encountered an issue where downloaded files that already existed on disk when re-downloaded from S3 could end up being corrupted. For example in case S3 file is smaller than the previous file, the written file after copy would keep previous files contents at the end.

The situation does not happen if the file is downloaded once.

Use `O_TRUNC` to avoid this scenario.